### PR TITLE
[Release] Sprint 22 2차 배포

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-6214559505940019, DIRECT, f08c47fec0942fa0

--- a/src/components/AdSenseUnit/AdSenseUnit.tsx
+++ b/src/components/AdSenseUnit/AdSenseUnit.tsx
@@ -5,25 +5,18 @@ import cn from '@/lib/cn';
 import { usePathname } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 
-declare global {
-  interface Window {
-    adsbygoogle?: object[];
-  }
-}
-
-interface AdSenseUnitProps {
-  slot: string | undefined;
-  format?: 'auto' | 'horizontal' | 'rectangle';
-  className?: string;
-}
-
 export default function AdSenseUnit({
   slot,
   format = 'auto',
   className,
-}: AdSenseUnitProps) {
-  const pathname = usePathname();
+}: {
+  slot: string | undefined;
+  format?: 'auto' | 'horizontal' | 'rectangle';
+  className?: string;
+}) {
   const insRef = useRef<HTMLModElement>(null);
+
+  const pathname = usePathname();
 
   useEffect(() => {
     const ins = insRef.current;

--- a/src/components/AdSenseUnit/AdSenseUnit.tsx
+++ b/src/components/AdSenseUnit/AdSenseUnit.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { ADSENSE_CLIENT_ID, ADSENSE_PLACEHOLDER_HEIGHT } from '@/constants';
+import cn from '@/lib/cn';
+import { usePathname } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+
+declare global {
+  interface Window {
+    adsbygoogle?: object[];
+  }
+}
+
+interface AdSenseUnitProps {
+  slot: string | undefined;
+  format?: 'auto' | 'horizontal' | 'rectangle';
+  className?: string;
+}
+
+export default function AdSenseUnit({
+  slot,
+  format = 'auto',
+  className,
+}: AdSenseUnitProps) {
+  const pathname = usePathname();
+  const insRef = useRef<HTMLModElement>(null);
+
+  useEffect(() => {
+    const ins = insRef.current;
+    if (!ins || ins.offsetWidth === 0 || ins.getAttribute('data-ad-status'))
+      return;
+    try {
+      (window.adsbygoogle = window.adsbygoogle || []).push({});
+    } catch {}
+  }, [pathname]);
+
+  if (!slot) return null;
+
+  if (process.env.NODE_ENV !== 'production') {
+    return (
+      <div
+        className={cn(
+          'flex items-center justify-center rounded-lg bg-gray-05 text-sm-200 text-gray-40',
+          ADSENSE_PLACEHOLDER_HEIGHT[format],
+          className,
+        )}
+      >
+        AdSense ({slot})
+      </div>
+    );
+  }
+
+  return (
+    <ins
+      key={pathname}
+      ref={insRef}
+      className={cn('adsbygoogle block', className)}
+      data-ad-client={ADSENSE_CLIENT_ID}
+      data-ad-slot={slot}
+      data-ad-format={format}
+      data-full-width-responsive={format === 'auto' ? 'true' : undefined}
+    />
+  );
+}

--- a/src/components/AdSenseUnit/index.tsx
+++ b/src/components/AdSenseUnit/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './AdSenseUnit';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -11,6 +11,13 @@ export const SHORT_URL_DOMAIN =
 export const DISCORD_API_URL =
   process.env.NEXT_PUBLIC_DISCORD_API_URL || DEFAULT_URL;
 
+export const ADSENSE_CLIENT_ID = 'ca-pub-6214559505940019';
+export const ADSENSE_PLACEHOLDER_HEIGHT = {
+  auto: 'h-[100px]',
+  horizontal: 'h-[60px]',
+  rectangle: 'h-[250px]',
+};
+
 export const LOCALES = ['ko', 'en'] as const;
 export const POLICY_KEY_LIST = ['privacy', 'service'] as const;
 

--- a/src/features/event/components/detail/MainContent/DesktopSideContent/DesktopSideContent.tsx
+++ b/src/features/event/components/detail/MainContent/DesktopSideContent/DesktopSideContent.tsx
@@ -5,7 +5,9 @@ import {
   RecommendedTimesHeading,
   RecommendedTimesList,
 } from './RecommendedTimes';
+import AdSenseUnit from '@/components/AdSenseUnit';
 import { useEventQuery } from '@/features/event/api/event.query';
+import { EVENT_DETAIL_ADSENSE_SLOT } from '@/features/event/constants';
 import { useSchedulesQuery } from '@/features/schedule/api/schedule.query';
 import { useParams } from 'next/navigation';
 
@@ -22,12 +24,14 @@ export default function DesktopSideContent() {
       {!isSchedulesPending && schedules.length === 0 ? (
         <>
           <BannerList className="pt-2" />
+          <AdSenseUnit slot={EVENT_DETAIL_ADSENSE_SLOT} className="mt-3" />
           <EmptyEventBanner />
         </>
       ) : (
         <>
           <RecommendedTimesHeading />
           <BannerList className="pt-2" />
+          <AdSenseUnit slot={EVENT_DETAIL_ADSENSE_SLOT} className="mt-3" />
           <RecommendedTimesList />
         </>
       )}

--- a/src/features/event/components/detail/MainContent/MainContent.tsx
+++ b/src/features/event/components/detail/MainContent/MainContent.tsx
@@ -4,7 +4,9 @@ import ConfirmedTime from '../shared/ConfirmedTime';
 import BannerList from './BannerList';
 import DesktopSideContent from './DesktopSideContent';
 import ParticipantFilter from './ParticipantFilter';
+import AdSenseUnit from '@/components/AdSenseUnit';
 import { useEventQuery } from '@/features/event/api/event.query';
+import { EVENT_DETAIL_ADSENSE_SLOT } from '@/features/event/constants';
 import { EventParticipantFilterContext } from '@/features/event/contexts/EventParticipantFilterContext';
 import useTopContentHeight from '@/features/event/hooks/useTopContentHeight';
 import TimeBlockBoard from '@/features/schedule/components/shared/TimeBlockBoard';
@@ -31,6 +33,11 @@ export default function MainContent() {
           </div>
         )}
         <BannerList className="md:hidden" />
+        <AdSenseUnit
+          slot={EVENT_DETAIL_ADSENSE_SLOT}
+          format="horizontal"
+          className="mt-3 md:hidden"
+        />
         <ParticipantFilter />
         <TimeBlockBoard
           event={event}
@@ -39,6 +46,11 @@ export default function MainContent() {
           topContentStyle={{
             top: stickyTop,
           }}
+        />
+        <AdSenseUnit
+          slot={EVENT_DETAIL_ADSENSE_SLOT}
+          format="rectangle"
+          className="mt-4 md:hidden"
         />
       </div>
       <DesktopSideContent />

--- a/src/features/event/constants/index.ts
+++ b/src/features/event/constants/index.ts
@@ -7,6 +7,9 @@ import {
 
 export const EDITED_EVENTS_COOKIE_KEY = 'edited_events';
 
+export const EVENT_DETAIL_ADSENSE_SLOT =
+  process.env.NEXT_PUBLIC_ADSENSE_EVENT_DETAIL_SLOT;
+
 export const TALK_CALENDAR_EVENT_ID = 'talk_calendar_event_id';
 export const TALK_CALENDAR_SUCCESS = 'success';
 export const TALK_CALENDAR_ERROR = 'error';

--- a/src/features/set-up/components/Scripts/GoogleAdSense/GoogleAdSense.tsx
+++ b/src/features/set-up/components/Scripts/GoogleAdSense/GoogleAdSense.tsx
@@ -1,10 +1,11 @@
+import { ADSENSE_CLIENT_ID } from '@/constants';
 import Script from 'next/script';
 
 export default function GoogleAdSense() {
   return (
     <Script
       async
-      src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6214559505940019"
+      src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${ADSENSE_CLIENT_ID}`}
       crossOrigin="anonymous"
     ></Script>
   );

--- a/src/types/adsense.d.ts
+++ b/src/types/adsense.d.ts
@@ -1,0 +1,7 @@
+declare global {
+  interface Window {
+    adsbygoogle?: object[];
+  }
+}
+
+export {};


### PR DESCRIPTION
## 작업 내용

### 이벤트 상세 페이지 AdSense 광고
- 이벤트 상세 페이지에 AdSense 광고(`AdSenseUnit`)를 추가했습니다.
- AdSense 스크립트 로더(`GoogleAdSense`)를 통해 광고를 노출합니다.

### AdSense 타입 정리
- `AdSenseUnit` 컴포넌트에 인라인으로 있던 `Window.adsbygoogle` 전역 타입 선언을 `src/types/adsense.d.ts`로 분리했습니다.
- 컴포넌트 props 타입(`AdSenseUnitProps` interface)을 제거하고 함수 시그니처에 인라인했습니다.

## 확인

- `tsc --noEmit` 통과
