### PR TITLE
[Hotfix] AdSense 광고 push 미호출로 광고가 안 뜨던 문제 수정

### DIFF
--- a/src/components/AdSenseUnit/AdSenseUnit.tsx
+++ b/src/components/AdSenseUnit/AdSenseUnit.tsx
@@ -25,16 +25,19 @@ export default function AdSenseUnit({
   const isMobile = useIsMobile();
   const mounted = useMounted();
 
+  const active = !!slot && mounted && (device === 'desktop') !== isMobile;
+
   useEffect(() => {
+    if (!active) return;
     const ins = insRef.current;
     if (!ins || ins.offsetWidth === 0 || ins.getAttribute('data-ad-status'))
       return;
     try {
       (window.adsbygoogle = window.adsbygoogle || []).push({});
     } catch {}
-  }, [pathname]);
+  }, [pathname, active]);
 
-  if (!slot || !mounted || (device === 'desktop') === isMobile) return null;
+  if (!active) return null;
 
   if (process.env.NODE_ENV !== 'production') {
     return (


### PR DESCRIPTION
## 작업 내용

### AdSense push 회귀 수정 (`src/components/AdSenseUnit`)
직전 PR(#181)에서 추가한 `mounted` 가드 때문에 `<ins>`가 push effect 실행보다 늦게 마운트되어 `adsbygoogle.push({})`가 한 번도 호출되지 않았고, 결과적으로 데스크탑/모바일 광고가 모두 안 뜨던 문제를 수정합니다.

- 렌더 조건을 `active`(`slot` 존재 + `mounted` + 현재 뷰포트 일치)로 묶고, push effect 의존성에 `active`를 추가해 `<ins>`가 실제로 마운트되는 시점에 push가 재실행되도록 함.
- 조건부 마운트의 이점(숨겨진 `<ins>`가 push를 가로채는 문제 방지)은 그대로 유지.

> 이 버그는 프로덕션 빌드에서만 드러납니다. 로컬 dev는 placeholder div를 렌더해 push 경로를 타지 않기 때문입니다.

## 확인
- `pnpm tsc --noEmit` 통과
- `pnpm next build` 통과