### PR TITLE
[Hotfix] 모바일 가로 광고 크기가 안 먹히던 문제 수정

### DIFF
--- a/src/components/AdSenseUnit/AdSenseUnit.tsx
+++ b/src/components/AdSenseUnit/AdSenseUnit.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ADSENSE_CLIENT_ID, ADSENSE_PLACEHOLDER_HEIGHT } from '@/constants';
+import { ADSENSE_CLIENT_ID } from '@/constants';
 import useIsMobile from '@/hooks/useIsMobile';
 import useMounted from '@/hooks/useMounted';
 import cn from '@/lib/cn';
@@ -10,12 +10,12 @@ import { useEffect, useRef } from 'react';
 export default function AdSenseUnit({
   slot,
   device,
-  format = 'auto',
+  fixedSize,
   className,
 }: {
   slot: string | undefined;
   device: 'mobile' | 'desktop';
-  format?: 'auto' | 'horizontal' | 'rectangle';
+  fixedSize?: { width: number; height: number };
   className?: string;
 }) {
   const insRef = useRef<HTMLModElement>(null);
@@ -44,12 +44,26 @@ export default function AdSenseUnit({
       <div
         className={cn(
           'flex items-center justify-center rounded-lg bg-gray-05 text-sm-200 text-gray-40',
-          ADSENSE_PLACEHOLDER_HEIGHT[format],
+          fixedSize ? 'mx-auto' : 'h-[100px]',
           className,
         )}
+        style={fixedSize}
       >
         AdSense ({slot})
       </div>
+    );
+  }
+
+  if (fixedSize) {
+    return (
+      <ins
+        key={pathname}
+        ref={insRef}
+        className={cn('adsbygoogle mx-auto block', className)}
+        style={fixedSize}
+        data-ad-client={ADSENSE_CLIENT_ID}
+        data-ad-slot={slot}
+      />
     );
   }
 
@@ -57,15 +71,11 @@ export default function AdSenseUnit({
     <ins
       key={pathname}
       ref={insRef}
-      className={cn(
-        'adsbygoogle block',
-        format !== 'auto' && ADSENSE_PLACEHOLDER_HEIGHT[format],
-        className,
-      )}
+      className={cn('adsbygoogle block', className)}
       data-ad-client={ADSENSE_CLIENT_ID}
       data-ad-slot={slot}
-      data-ad-format={format}
-      data-full-width-responsive={format === 'auto' ? 'true' : undefined}
+      data-ad-format="auto"
+      data-full-width-responsive="true"
     />
   );
 }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -19,11 +19,6 @@ export const ADSENSE_SLOTS = {
     desktop: '5366472351',
   },
 };
-export const ADSENSE_PLACEHOLDER_HEIGHT = {
-  auto: 'h-[100px]',
-  horizontal: 'h-[60px]',
-  rectangle: 'h-[250px]',
-};
 
 export const LOCALES = ['ko', 'en'] as const;
 export const POLICY_KEY_LIST = ['privacy', 'service'] as const;

--- a/src/features/event/components/detail/MainContent/MainContent.tsx
+++ b/src/features/event/components/detail/MainContent/MainContent.tsx
@@ -36,7 +36,7 @@ export default function MainContent() {
         <AdSenseUnit
           slot={ADSENSE_SLOTS.eventDetail.mobileHorizontal}
           device="mobile"
-          format="horizontal"
+          fixedSize={{ width: 320, height: 100 }}
           className="mt-3 md:hidden"
         />
         <ParticipantFilter />
@@ -51,7 +51,6 @@ export default function MainContent() {
         <AdSenseUnit
           slot={ADSENSE_SLOTS.eventDetail.mobileRectangle}
           device="mobile"
-          format="rectangle"
           className="mt-4 md:hidden"
         />
       </div>


### PR DESCRIPTION
## 작업 내용

### 모바일 가로 광고 크기 수정 (`src/components/AdSenseUnit`)
광고 단위가 고정 크기로 생성되어 있어 반응형 `data-ad-format="horizontal"` 힌트가 적용되지 않고 사각형으로 뜨던 문제를 수정합니다.

- 고정 크기(320x100)로 `<ins>`를 렌더하는 `fixedSize` prop 추가 (`data-ad-format` / `full-width-responsive` 없이 명시적 width/height, 중앙 정렬).
- 반응형/고정 구분을 `fixedSize` 유무로 일원화 → 더 이상 쓰지 않는 `format` prop과 `ADSENSE_PLACEHOLDER_HEIGHT` 상수 제거. 반응형은 `auto`, 특정 모양은 `fixedSize`로 처리.
- 모바일 사각형 / 데스크탑 광고는 반응형(auto) 유지.

> 대시보드에서 `event-detail-mobile-horizontal` 단위 크기를 320x100으로 맞춰야 실제 광고가 해당 크기로 노출됩니다.

## 확인
- `pnpm tsc --noEmit` 통과
- `pnpm next build` 통과