### PR TITLE
[Hotfix] 서버 이전 후 QR·배너 이미지 미표시 해결

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -18,6 +18,11 @@ const nextConfig: NextConfig = {
         hostname: 'onetime-bucket.s3.ap-northeast-2.amazonaws.com',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'api.onetime.run',
+        pathname: '/files/**',
+      },
     ],
   },
 };


### PR DESCRIPTION
## 작업 내용

- `next.config.ts`의 `images.remotePatterns`에 `api.onetime.run` 추가 (`/files/**`)
  - 백엔드 서버 이전으로 이미지 저장소가 **S3 → API 서버 로컬 디스크**로 변경됨
  - 이미지 URL: `onetime-bucket.s3.ap-northeast-2.amazonaws.com/...` → `api.onetime.run/files/...`
  - `next/image`는 `remotePatterns`에 없는 호스트를 400으로 차단하므로, QR 코드(이벤트 4,907건)와 배너 이미지가 표시되지 않음
- 기존 S3 항목은 그대로 유지

## 확인

- `tsc --noEmit` 통과
- `next build` 성공
- `prettier --check` 통과
- 신규 서버 이미지 서빙 확인: `GET https://api.onetime.run/files/qr/<key>` → 200 `image/png`

## 배포 후 확인

이벤트 상세 → 공유 → QR 코드 화면에서 QR이 표시되면 완료