### PR TITLE
[Hotfix] 오라클 서버 이전 대비 Docker 빌드·GHCR 배포 CI 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+.next
+.open-next
+.wrangler
+.git
+.idea
+cypress
+Dockerfile
+.dockerignore
+.env*
+tsconfig.tsbuildinfo

--- a/.github/workflows/prod-cicd.yaml
+++ b/.github/workflows/prod-cicd.yaml
@@ -1,0 +1,99 @@
+name: 🚀 Build & Deploy workflow on prod environment
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: '배포 환경'
+        required: true
+        default: 'prod'
+        type: choice
+        options:
+          - prod
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build and Push to GHCR
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04-arm
+    environment: prod
+    outputs:
+      image_tag: ${{ steps.meta.outputs.tag }}
+
+    steps:
+      - name: ✅ 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: 🏷️ 이미지 태그 생성
+        id: meta
+        run: |
+          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
+          TIMESTAMP=$(TZ='Asia/Seoul' date +'%Y%m%d%H%M%S')
+          IMAGE_TAG="${TIMESTAMP}-${SHORT_SHA}"
+          echo "tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+
+      - name: 🔐 GHCR 로그인
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🏗️ Docker Buildx 설정
+        uses: docker/setup-buildx-action@v3
+
+      - name: 📦 Docker 이미지 빌드 및 GHCR 푸시
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/arm64
+          # NEXT_PUBLIC_* 은 빌드 타임에 번들로 인라인되므로 여기서 주입한다 (서버 .env 아님)
+          build-args: |
+            NEXT_PUBLIC_SERVER_API_URL=${{ vars.NEXT_PUBLIC_SERVER_API_URL }}
+            NEXT_PUBLIC_SITE_DOMAIN=${{ vars.NEXT_PUBLIC_SITE_DOMAIN }}
+            NEXT_PUBLIC_SHORT_URL_DOMAIN=${{ vars.NEXT_PUBLIC_SHORT_URL_DOMAIN }}
+            NEXT_PUBLIC_KAKAO_JS_KEY=${{ vars.NEXT_PUBLIC_KAKAO_JS_KEY }}
+            NEXT_PUBLIC_GA_ID=${{ vars.NEXT_PUBLIC_GA_ID }}
+            NEXT_PUBLIC_GTM_ID=${{ vars.NEXT_PUBLIC_GTM_ID }}
+            NEXT_PUBLIC_META_PIXEL_ID=${{ vars.NEXT_PUBLIC_META_PIXEL_ID }}
+            NEXT_PUBLIC_MS_CLARITY_ID=${{ vars.NEXT_PUBLIC_MS_CLARITY_ID }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tag }}
+            ${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy to Server
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    environment: prod
+    steps:
+      # 서버가 Oracle Cloud 라 SSM 을 쓸 수 없다. SSH 로 직접 실행한다. (backend 와 동일 방식)
+      - name: 🔑 SSH 키 설정
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          # ssh-keyscan 으로 그때그때 받아오면 중간자를 검증 없이 신뢰하게 된다. 호스트키를 고정한다.
+          printf '%s\n' "${{ secrets.SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: 🚀 서버에 배포 스크립트 실행 (SSH)
+        env:
+          IMAGE_TAG: ${{ needs.build-and-push.outputs.image_tag }}
+        run: |
+          ssh -i ~/.ssh/deploy_key -o BatchMode=yes \
+            "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" \
+            "GHCR_USERNAME='${{ github.actor }}' GHCR_TOKEN='${{ secrets.GITHUB_TOKEN }}' /home/ubuntu/deploy/deploy-frontend.sh ${IMAGE_TAG}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# syntax=docker/dockerfile:1
+
+FROM node:22-alpine AS base
+RUN corepack enable pnpm
+
+FROM base AS deps
+WORKDIR /app
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile
+
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# NEXT_PUBLIC_* 은 빌드 타임에 번들로 인라인되므로 build-arg 로 받아야 한다.
+# 서버 .env 로는 주입되지 않는다.
+ARG NEXT_PUBLIC_SERVER_API_URL
+ARG NEXT_PUBLIC_SITE_DOMAIN
+ARG NEXT_PUBLIC_SHORT_URL_DOMAIN
+ARG NEXT_PUBLIC_KAKAO_JS_KEY
+ARG NEXT_PUBLIC_GA_ID
+ARG NEXT_PUBLIC_GTM_ID
+ARG NEXT_PUBLIC_META_PIXEL_ID
+ARG NEXT_PUBLIC_MS_CLARITY_ID
+ENV NEXT_PUBLIC_SERVER_API_URL=$NEXT_PUBLIC_SERVER_API_URL \
+    NEXT_PUBLIC_SITE_DOMAIN=$NEXT_PUBLIC_SITE_DOMAIN \
+    NEXT_PUBLIC_SHORT_URL_DOMAIN=$NEXT_PUBLIC_SHORT_URL_DOMAIN \
+    NEXT_PUBLIC_KAKAO_JS_KEY=$NEXT_PUBLIC_KAKAO_JS_KEY \
+    NEXT_PUBLIC_GA_ID=$NEXT_PUBLIC_GA_ID \
+    NEXT_PUBLIC_GTM_ID=$NEXT_PUBLIC_GTM_ID \
+    NEXT_PUBLIC_META_PIXEL_ID=$NEXT_PUBLIC_META_PIXEL_ID \
+    NEXT_PUBLIC_MS_CLARITY_ID=$NEXT_PUBLIC_MS_CLARITY_ID \
+    NEXT_TELEMETRY_DISABLED=1
+RUN pnpm build
+
+FROM node:22-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production \
+    HOSTNAME=0.0.0.0 \
+    PORT=3000 \
+    NEXT_TELEMETRY_DISABLED=1
+
+COPY --from=builder --chown=node:node /app/.next/standalone ./
+COPY --from=builder --chown=node:node /app/.next/static ./.next/static
+COPY --from=builder --chown=node:node /app/public ./public
+
+USER node
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from 'next';
 import createNextIntlPlugin from 'next-intl/plugin';
 
 const nextConfig: NextConfig = {
+  output: 'standalone',
   turbopack: {},
   webpack: (config) => {
     config.module.rules.push({
@@ -21,6 +22,11 @@ const nextConfig: NextConfig = {
       {
         protocol: 'https',
         hostname: 'api.onetime.run',
+        pathname: '/files/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'api.onetime-with-members.com',
         pathname: '/files/**',
       },
     ],


### PR DESCRIPTION
## 작업 내용

프론트를 Cloudflare Workers에서 오라클 서버(Docker)로 이전하기 위한 사전 세팅입니다. 머지해도 기존 Workers 배포는 그대로 동작합니다 (전환 검증 후 별도 PR로 정리 예정).

- **next.config.ts**: `output: 'standalone'` 추가 (Docker 셀프호스팅용), 이미지 허용 호스트에 `api.onetime-with-members.com` 추가
- **Dockerfile / .dockerignore**: pnpm 멀티스테이지 빌드 → Node standalone 실행 (`:3000`). `NEXT_PUBLIC_*`는 빌드 타임 인라인이라 build-arg로 주입
- **.github/workflows/prod-cicd.yaml**: main 머지 시 ARM64 이미지 빌드 → GHCR 푸시 → SSH로 서버 배포 (backend prod-cicd와 동일 패턴)

## 확인

- `pnpm build` 통과 (standalone 출력 + sharp 트레이싱 확인)
- deploy 단계는 서버에 배포 스크립트 반영 전까지 실패가 정상입니다 (이미지 푸시까지만 유효)
- 리포 Environments(prod)에 Variables/Secrets 등록 필요 — 별도 공유

🤖 Generated with [Claude Code](https://claude.com/claude-code)