### PR TITLE
[Hotfix] 프론트 이미지 빌드 GHA 캐시 오류 우회

### DIFF
--- a/.github/workflows/prod-cicd.yaml
+++ b/.github/workflows/prod-cicd.yaml
@@ -71,8 +71,6 @@ jobs:
           tags: |
             ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tag }}
             ${{ env.IMAGE_NAME }}:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   deploy:
     name: Deploy to Server


### PR DESCRIPTION
## 작업 내용
- prod-cicd.yaml의 buildx `cache-from/cache-to: type=gha` 제거 — GHA 캐시 서비스 `failed to reserve cache` 오류로 빌드가 2회 연속 실패하여 캐시 없이 빌드하도록 변경

## 확인
- 머지 후 prod-cicd 빌드 성공 여부로 확인